### PR TITLE
remove docker check 

### DIFF
--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 )
 
 const (
@@ -52,7 +51,7 @@ func (c *Config) SetCredHelper(registry, helper string) {
 
 func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]byte, error) {
 	for _, cred := range credentials {
-		if cred.Registry != "" && strings.Contains(cred.Registry, "docker") {
+		if cred.Registry != "" {
 
 			if cred.Username == "" {
 				return nil, fmt.Errorf("Username must be specified for registry: %s", cred.Registry)


### PR DESCRIPTION
The docker string match check for registry while adding to config is removed to support other docker compliant registries too.

