### PR TITLE
fix:[CI-13562]:improve error message for anonymous connector used

### DIFF
--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -54,10 +54,10 @@ func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]by
 		if cred.Registry != "" {
 
 			if cred.Username == "" {
-				return nil, fmt.Errorf("Username cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
+				return nil, fmt.Errorf("Username cannot be null, remove the anonymous connector if it is used as a base image connector: %s", cred.Registry)
 			}
 			if cred.Password == "" {
-				return nil, fmt.Errorf("Password cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
+				return nil, fmt.Errorf("Password cannot be null, remove the anonymous connector if it is used as a base image connector: %s", cred.Registry)
 			}
 			c.SetAuth(cred.Registry, cred.Username, cred.Password)
 		}

--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -54,10 +54,10 @@ func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]by
 		if cred.Registry != "" {
 
 			if cred.Username == "" {
-				return nil, fmt.Errorf("Username must be specified for registry: %s", cred.Registry)
+				return nil, fmt.Errorf("Username cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
 			}
 			if cred.Password == "" {
-				return nil, fmt.Errorf("Password must be specified for registry: %s", cred.Registry)
+				return nil, fmt.Errorf("Password cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
 			}
 			c.SetAuth(cred.Registry, cred.Username, cred.Password)
 		}


### PR DESCRIPTION
Ticket : https://harness.atlassian.net/browse/CI-12799

Here the ask was to validate anonymous connector on save, but we want to minimize validations on save for efficiency. The other ask was for a proper error message in case anonymous connector is used as base image connector, but since this pull would be successful even without the connector we are throwing a suggestive error.  