### PR TITLE
fix:[CI-13562]:improve error message for anonymous connector used

### DIFF
--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -54,10 +54,10 @@ func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]by
 		if cred.Registry != "" {
 
 			if cred.Username == "" {
-				return nil, fmt.Errorf("Username cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
+				return nil, fmt.Errorf("Username cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
 			}
 			if cred.Password == "" {
-				return nil, fmt.Errorf("Password cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
+				return nil, fmt.Errorf("Password cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
 			}
 			c.SetAuth(cred.Registry, cred.Username, cred.Password)
 		}

--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -54,10 +54,10 @@ func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]by
 		if cred.Registry != "" {
 
 			if cred.Username == "" {
-				return nil, fmt.Errorf("Username must be specified for registry: %s", cred.Registry)
+				return nil, fmt.Errorf("Username cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
 			}
 			if cred.Password == "" {
-				return nil, fmt.Errorf("Password must be specified for registry: %s", cred.Registry)
+				return nil, fmt.Errorf("Password cannot be null, anonymous connector is not supported for base image pull: %s", cred.Registry)
 			}
 			c.SetAuth(cred.Registry, cred.Username, cred.Password)
 		}

--- a/config/docker/config.go
+++ b/config/docker/config.go
@@ -54,10 +54,10 @@ func (c *Config) CreateDockerConfigJson(credentials []RegistryCredentials) ([]by
 		if cred.Registry != "" {
 
 			if cred.Username == "" {
-				return nil, fmt.Errorf("Username cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
+				return nil, fmt.Errorf("Username must be specified for registry: %s", cred.Registry)
 			}
 			if cred.Password == "" {
-				return nil, fmt.Errorf("Password cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
+				return nil, fmt.Errorf("Password must be specified for registry: %s", cred.Registry)
 			}
 			c.SetAuth(cred.Registry, cred.Username, cred.Password)
 		}

--- a/docker.go
+++ b/docker.go
@@ -185,6 +185,12 @@ func (p Plugin) Exec() error {
 		baseConnectorLogin.Password = p.BaseImagePassword
 
 		cmd := commandLogin(baseConnectorLogin)
+		if p.BaseImageUsername == "" {
+			return fmt.Errorf("Username cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
+		}
+		if p.BaseImagePassword == "" {
+			return fmt.Errorf("Password cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
+		}
 
 		raw, err := cmd.CombinedOutput()
 		if err != nil {

--- a/docker.go
+++ b/docker.go
@@ -178,19 +178,19 @@ func (p Plugin) Exec() error {
 
 	// add base image docker credentials to the existing config file, else create new
 	// instead of writing to config file directly, using docker's login func
-	if p.BaseImagePassword != "" {
-		var baseConnectorLogin Login
-		baseConnectorLogin.Registry = p.BaseImageRegistry
-		baseConnectorLogin.Username = p.BaseImageUsername
-		baseConnectorLogin.Password = p.BaseImagePassword
-
-		cmd := commandLogin(baseConnectorLogin)
+	if p.BaseImageRegistry != "" {
 		if p.BaseImageUsername == "" {
 			return fmt.Errorf("Username cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
 		}
 		if p.BaseImagePassword == "" {
 			return fmt.Errorf("Password cannot be empty. The base image connector requires authenticated access. Please either use an authenticated connector, or remove the base image connector.")
 		}
+		var baseConnectorLogin Login
+		baseConnectorLogin.Registry = p.BaseImageRegistry
+		baseConnectorLogin.Username = p.BaseImageUsername
+		baseConnectorLogin.Password = p.BaseImagePassword
+
+		cmd := commandLogin(baseConnectorLogin)
 
 		raw, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Ticket : https://harness.atlassian.net/browse/CI-12799

Here the ask was to validate anonymous connector on save, but we want to minimize validations on save for efficiency. The other ask was for a proper error message in case anonymous connector is used as base image connector, but since this pull would be successful even without the connector we are throwing a suggestive error.