### PR TITLE
Updated base image for win-1809 dockerfile

### DIFF
--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -1,19 +1,21 @@
 # escape=`
-FROM mcr.microsoft.com/windows/servercore:ltsc2022 as download
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV DOCKER_VERSION 19.03.1
 
-RUN Invoke-WebRequest 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip' -OutFile 'innoextract.zip' -UseBasicParsing ; `
+RUN Invoke-WebRequest 'http://constexpr.org/innoextract/files/innoextract-1.6-windows.zip' -OutFile 'innoextract.zip' -UseBasicParsing ; `
     Expand-Archive innoextract.zip -DestinationPath C:\ ; `
     Remove-Item -Path innoextract.zip
 
+# Download Docker Toolbox
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
 RUN /innoextract.exe dockertoolbox.exe
 
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2019
+
 USER ContainerAdministrator
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `

--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -1,12 +1,11 @@
 # escape=`
-# using 1809-KB5021237-amd64 as base image, 1809-KB5022286-amd64 does not work
-FROM mcr.microsoft.com/windows/servercore:1809-KB5021237 as download
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV DOCKER_VERSION 19.03.1
 
-RUN Invoke-WebRequest 'http://constexpr.org/innoextract/files/innoextract-1.6-windows.zip' -OutFile 'innoextract.zip' -UseBasicParsing ; `
+RUN Invoke-WebRequest 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip' -OutFile 'innoextract.zip' -UseBasicParsing ; `
     Expand-Archive innoextract.zip -DestinationPath C:\ ; `
     Remove-Item -Path innoextract.zip
 
@@ -14,8 +13,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
 RUN /innoextract.exe dockertoolbox.exe
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-KB5021237-amd64
-
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 USER ContainerAdministrator
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
@@ -27,4 +25,5 @@ RUN mkdir C:\bin
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe
 ADD release/windows/amd64/drone-docker.exe C:/bin/drone-docker.exe
+
 ENTRYPOINT [ "C:\\bin\\drone-docker.exe" ]


### PR DESCRIPTION
- Updated base image for win-1809 dockerfile from `servercore:1809` to `servercore:ltsc2022`