### PR TITLE
feat: [CI-16595]: Added new input PLUGIN_BUILDX_OPTIONS

### DIFF
--- a/app.go
+++ b/app.go
@@ -410,6 +410,11 @@ func Run() {
 			Usage:  "build target",
 			EnvVar: "PLUGIN_HARNESS_SELF_HOSTED_GCP_JSON_KEY",
 		},
+		cli.StringSliceFlag{
+			Name:   "buildx-options",
+			Usage:  "additional options to pass directly to the buildx command",
+			EnvVar: "PLUGIN_BUILDX_OPTIONS",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -471,6 +476,7 @@ func run(c *cli.Context) error {
 			HarnessSelfHostedS3AccessKey: c.String("harness-self-hosted-s3-access-key"),
 			HarnessSelfHostedS3SecretKey: c.String("harness-self-hosted-s3-secret-key"),
 			HarnessSelfHostedGcpJsonKey:  c.String("harness-self-hosted-gcp-json-key"),
+			BuildxOptions:                c.StringSlice("buildx-options"),
 		},
 		Daemon: Daemon{
 			Registry:         c.String("docker.registry"),

--- a/docker.go
+++ b/docker.go
@@ -94,6 +94,7 @@ type (
 		HarnessSelfHostedS3AccessKey string   // Harness self-hosted s3 access key
 		HarnessSelfHostedS3SecretKey string   // Harness self-hosted s3 secret key
 		HarnessSelfHostedGcpJsonKey  string   // Harness self hosted gcp json region
+		BuildxOptions                []string // Generic buildx options passed directly to the buildx command
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -580,6 +581,9 @@ func commandBuildx(build Build, builder Builder, dryrun bool, metadataFile strin
 		}
 	} else {
 		args = append(args, "--push")
+	}
+	if len(build.BuildxOptions) > 0 {
+		args = append(args, build.BuildxOptions...)
 	}
 	args = append(args, build.Context)
 	if metadataFile != "" {


### PR DESCRIPTION
Added new input PLUGIN_BUILDX_OPTIONS to pass any [supported options](https://docs.docker.com/reference/cli/docker/buildx/build/#options) to buildx command.

Tested the changes locally:
![image](https://github.com/user-attachments/assets/fb19ab3c-374e-4469-9d82-8376501928f4)

![image](https://github.com/user-attachments/assets/88250476-0ba5-427b-b81a-4c2d81888d47)
