### PR TITLE
feat: [CI-17135]: Add push-only mode and tar file support to Drone Buildx Plugin  PR Description

### DIFF
--- a/app.go
+++ b/app.go
@@ -415,6 +415,21 @@ func Run() {
 			Usage:  "additional options to pass directly to the buildx command",
 			EnvVar: "PLUGIN_BUILDX_OPTIONS",
 		},
+		cli.BoolFlag{
+			Name:   "push-only",
+			Usage:  "push only mode, skips build process",
+			EnvVar: "PLUGIN_PUSH_ONLY",
+		},
+		cli.StringFlag{
+			Name:   "source-tar-path",
+			Usage:  "path to Docker image tar file to load and push",
+			EnvVar: "PLUGIN_SOURCE_TAR_PATH",
+		},
+		cli.StringFlag{
+			Name:   "tar-path",
+			Usage:  "path to save Docker image as tar file",
+			EnvVar: "PLUGIN_TAR_PATH",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -510,6 +525,9 @@ func run(c *cli.Context) error {
 		BaseImageRegistry: c.String("docker.baseimageregistry"),
 		BaseImageUsername: c.String("docker.baseimageusername"),
 		BaseImagePassword: c.String("docker.baseimagepassword"),
+		PushOnly:          c.Bool("push-only"),
+		SourceTarPath:     c.String("source-tar-path"),
+		TarPath:           c.String("tar-path"),
 	}
 
 	if c.Bool("tags.auto") {

--- a/app.go
+++ b/app.go
@@ -28,7 +28,7 @@ func Run() {
 		cli.BoolFlag{
 			Name:   "dry-run",
 			Usage:  "dry run disables docker push",
-			EnvVar: "PLUGIN_DRY_RUN",
+			EnvVar: "PLUGIN_DRY_RUN, PLUGIN_NO_PUSH",
 		},
 		cli.StringFlag{
 			Name:   "remote.url",
@@ -428,7 +428,7 @@ func Run() {
 		cli.StringFlag{
 			Name:   "tar-path",
 			Usage:  "path to save Docker image as tar file",
-			EnvVar: "PLUGIN_TAR_PATH",
+			EnvVar: "PLUGIN_TAR_PATH, PLUGIN_DESTINATION_TAR_PATH",
 		},
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -112,6 +112,9 @@ type (
 		BaseImageRegistry string  // Docker registry to pull base image
 		BaseImageUsername string  // Docker registry username to pull base image
 		BaseImagePassword string  // Docker registry password to pull base image
+		PushOnly          bool    // Push only mode, skips build process
+		SourceTarPath     string  // Path to Docker image tar file to load and push
+		TarPath           string  // Path to save Docker image as tar file
 	}
 
 	Card []struct {
@@ -349,6 +352,11 @@ func (p Plugin) Exec() error {
 		}()
 	}
 
+	// Handle push-only mode if requested
+	if p.PushOnly {
+		return p.pushOnly()
+	}
+
 	// add proxy build args
 	addProxyBuildArgs(&p.Build)
 
@@ -358,7 +366,7 @@ func (p Plugin) Exec() error {
 	cmds = append(cmds, commandInfo())    // docker info
 
 	// Command to build, tag and push
-	cmds = append(cmds, commandBuildx(p.Build, p.Builder, p.Dryrun, p.MetadataFile)) // docker build
+	cmds = append(cmds, commandBuildx(p.Build, p.Builder, p.Dryrun, p.MetadataFile, p.TarPath)) // docker build
 
 	// execute all commands in batch mode.
 	for _, cmd := range cmds {
@@ -407,6 +415,42 @@ func (p Plugin) Exec() error {
 			fmt.Printf("Could not remove image %s. Ignoring...\n", cmd.Args[2])
 		} else if err != nil {
 			return err
+		}
+	}
+
+	if p.TarPath != "" && p.Dryrun {
+		if len(p.Build.Tags) > 0 {
+			tag := p.Build.Tags[0]
+			fullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
+
+			if !p.Build.BuildxLoad {
+				fmt.Printf("Warning: To save images to tar, 'load' must be enabled. Adding the '--load' flag automatically.\n")
+				p.Build.BuildxLoad = true
+			}
+
+			if !imageExists(fullImageName) {
+				fmt.Printf("Warning: Image %s not found in local daemon, cannot save to tar\n", fullImageName)
+			} else {
+				dir := filepath.Dir(p.TarPath)
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					fmt.Printf("Warning: Failed to create directory for tar file: %v\n", err)
+				}
+
+				// Save the image
+				fmt.Println("Saving image to tar:", p.TarPath)
+				saveCmd := commandSaveTar(fullImageName, p.TarPath)
+				saveCmd.Stdout = os.Stdout
+				saveCmd.Stderr = os.Stderr
+				trace(saveCmd)
+
+				if err := saveCmd.Run(); err != nil {
+					fmt.Printf("Warning: Failed to save image to tar: %v\n", err)
+				} else {
+					fmt.Printf("Successfully saved image to %s\n", p.TarPath)
+				}
+			}
+		} else {
+			fmt.Println("Warning: Cannot save image to tar, no tags specified")
 		}
 	}
 
@@ -559,7 +603,7 @@ func commandInfo() *exec.Cmd {
 }
 
 // helper function to create the docker buildx command.
-func commandBuildx(build Build, builder Builder, dryrun bool, metadataFile string) *exec.Cmd {
+func commandBuildx(build Build, builder Builder, dryrun bool, metadataFile string, tarPath string) *exec.Cmd {
 	args := []string{
 		"buildx",
 		"build",
@@ -576,7 +620,7 @@ func commandBuildx(build Build, builder Builder, dryrun bool, metadataFile strin
 		args = append(args, "-t", fmt.Sprintf("%s:%s", build.Repo, t))
 	}
 	if dryrun {
-		if build.BuildxLoad {
+		if build.BuildxLoad || tarPath != "" {
 			args = append(args, "--load")
 		}
 	} else {
@@ -882,6 +926,28 @@ func commandLoad() *exec.Cmd {
 	return exec.Command(dockerExe, "image", "load")
 }
 
+func commandLoadTar(tarPath string) *exec.Cmd {
+	return exec.Command(dockerExe, "load", "-i", tarPath)
+}
+
+func commandSaveTar(tag string, tarPath string) *exec.Cmd {
+	return exec.Command(dockerExe, "save", "-o", tarPath, tag)
+}
+
+func imageExists(tag string) bool {
+	cmd := exec.Command(dockerExe, "image", "inspect", tag)
+	return cmd.Run() == nil
+}
+
+func getDigestAfterPush(tag string) (string, error) {
+	cmd := exec.Command(dockerExe, "inspect", "--format", "{{ index (split (index .RepoDigests 0) \"@\") 1 }}", tag)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get digest for %s: %w", tag, err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 func writeSSHPrivateKey(key string) (path string, err error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -912,4 +978,90 @@ func updateImageVersion(driverOpts *[]string, version string) {
 			(*driverOpts)[i] = fmt.Sprintf("image=%s", version)
 		}
 	}
+}
+
+// pushOnly handles pushing images without building them
+func (p Plugin) pushOnly() error {
+	// If source tar path is provided, load the image first
+	if p.SourceTarPath != "" {
+		fmt.Println("Loading image from tar:", p.SourceTarPath)
+		loadCmd := commandLoadTar(p.SourceTarPath)
+		loadCmd.Stdout = os.Stdout
+		loadCmd.Stderr = os.Stderr
+		trace(loadCmd)
+		if err := loadCmd.Run(); err != nil {
+			return fmt.Errorf("failed to load image from tar: %w", err)
+		}
+	}
+
+	// For each tag, verify image exists and push
+	var digest string
+	for _, tag := range p.Build.Tags {
+		fullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
+
+		// Check if image exists in local daemon
+		if !imageExists(fullImageName) {
+			return fmt.Errorf("image %s not found, cannot push", fullImageName)
+		}
+
+		// Push image
+		fmt.Println("Pushing image:", fullImageName)
+		pushCmd := commandPush(p.Build, tag)
+		pushCmd.Stdout = os.Stdout
+		pushCmd.Stderr = os.Stderr
+		trace(pushCmd)
+		if err := pushCmd.Run(); err != nil {
+			return fmt.Errorf("failed to push image %s: %w", fullImageName, err)
+		}
+
+		// Get the digest after push (we only need one)
+		if digest == "" {
+			d, err := getDigestAfterPush(fullImageName)
+			if err == nil {
+				digest = d
+			} else {
+				fmt.Printf("Warning: Could not get digest for %s: %v\n", fullImageName, err)
+			}
+		}
+	}
+
+	// Output the adaptive card
+	if p.Builder.Driver == defaultDriver {
+		if err := p.writeCard(); err != nil {
+			fmt.Printf("Could not create adaptive card. %s\n", err)
+		}
+	}
+
+	// Write to artifact file
+	if p.ArtifactFile != "" && digest != "" {
+		if err := drone.WritePluginArtifactFile(
+			p.Daemon.RegistryType,
+			p.ArtifactFile,
+			p.Daemon.ArtifactRegistry,
+			p.Build.Repo,
+			digest,
+			p.Build.Tags,
+		); err != nil {
+			fmt.Printf("Failed to write plugin artifact file at path: %s with error: %s\n",
+				p.ArtifactFile, err)
+		}
+	}
+
+	var cmds []*exec.Cmd
+	// execute cleanup routines in batch mode
+	if p.Cleanup {
+		// clear the slice
+		cmds = nil
+
+		cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
+		cmds = append(cmds, commandPrune())           // docker system prune -f
+
+		for _, cmd := range cmds {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			trace(cmd)
+		}
+	}
+
+	return nil
 }

--- a/docker.go
+++ b/docker.go
@@ -1055,21 +1055,5 @@ func (p Plugin) pushOnly() error {
 		}
 	}
 
-	var cmds []*exec.Cmd
-	// execute cleanup routines in batch mode
-	if p.Cleanup {
-		// clear the slice
-		cmds = nil
-
-		cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
-		cmds = append(cmds, commandPrune())           // docker system prune -f
-
-		for _, cmd := range cmds {
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			trace(cmd)
-		}
-	}
-
 	return nil
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -339,3 +339,62 @@ func TestGetDigest(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandLoadTar(t *testing.T) {
+	tests := []struct {
+		name    string
+		tarPath string
+		want    *exec.Cmd
+	}{
+		{
+			name:    "simple path",
+			tarPath: "/path/to/image.tar",
+			want:    exec.Command(dockerExe, "load", "-i", "/path/to/image.tar"),
+		},
+		{
+			name:    "path with spaces",
+			tarPath: "/path with spaces/image.tar",
+			want:    exec.Command(dockerExe, "load", "-i", "/path with spaces/image.tar"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := commandLoadTar(tt.tarPath)
+			if !reflect.DeepEqual(cmd.String(), tt.want.String()) {
+				t.Errorf("commandLoadTar() = %v, want %v", cmd, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandSaveTar(t *testing.T) {
+	tests := []struct {
+		name    string
+		tag     string
+		tarPath string
+		want    *exec.Cmd
+	}{
+		{
+			name:    "simple inputs",
+			tag:     "myimage:latest",
+			tarPath: "/path/to/output.tar",
+			want:    exec.Command(dockerExe, "save", "-o", "/path/to/output.tar", "myimage:latest"),
+		},
+		{
+			name:    "complex registry",
+			tag:     "registry.example.com/project/image:v1.2.3",
+			tarPath: "/output/dir/image.tar",
+			want:    exec.Command(dockerExe, "save", "-o", "/output/dir/image.tar", "registry.example.com/project/image:v1.2.3"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := commandSaveTar(tt.tag, tt.tarPath)
+			if !reflect.DeepEqual(cmd.String(), tt.want.String()) {
+				t.Errorf("commandSaveTar() = %v, want %v", cmd, tt.want)
+			}
+		})
+	}
+}

--- a/docker_test.go
+++ b/docker_test.go
@@ -212,7 +212,7 @@ func TestCommandBuildx(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := commandBuildx(tc.build, tc.builder, tc.dryrun, tc.metadata)
+			cmd := commandBuildx(tc.build, tc.builder, tc.dryrun, tc.metadata, "")
 			if !reflect.DeepEqual(cmd.String(), tc.want.String()) {
 				t.Errorf("Got cmd %v, want %v", cmd, tc.want)
 			}


### PR DESCRIPTION
This PR enhances the Drone Buildx Plugin by adding three new features:

1. Push-Only Mode (**PLUGIN_PUSH_ONLY**): Enables pushing existing Docker images without building them:
        - Skips the build process entirely
        - Verifies images exist in the local daemon before pushing
        - Supports multiple tags
        - Preserves existing functionality for artifact files and adaptive cards

2. Source Tar Path (**PLUGIN_SOURCE_TAR_PATH**): Allows loading Docker images from a tar file before pushing:
        - Used in conjunction with push-only mode
        - Loads images from the specified tar file into the local daemon
        - Provides clear error messages if loading fails
    
3. Tar Path (**PLUGIN_TAR_PATH**): Saves built or existing images to a tar file:
        - Works in dry-run mode
        - Automatically enables the --load flag when needed
        - Creates parent directories if they don't exist
        - Verifies images exist before attempting to save
        
Testing:
- Push-only mode works correctly with existing images [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/dronebuildxpushonlywithouttar/executions/QNzw-W3pQySwo3IXhQfDsg/pipeline?step=9Z9iIou7SZCEFo_0VLrcWw&stage=J_0cmJkeTfG0fJ7IXw9dJA&childStage=&stageExecId=)
- Images can be loaded from tar files and then pushed [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/dronebuildxpushonly/executions/xATY4__vQa6T9XWc0Q_TWg/pipeline?storeType=INLINE)
- Built images can be saved to tar files in dry-run mode [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/dronebuildxpushonly/executions/xATY4__vQa6T9XWc0Q_TWg/pipeline?storeType=INLINE&step=uPkxY0GQQ_2EpKrQK9zESg&stage=CogO5VUcTfqbBDegjJczxQ&childStage=&stageExecId=)
- Push-only with multiple tags [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/dronebuildxpushonlywithtar/executions/OSykwHEUQk65q6vJwjsUzA/pipeline?storeType=INLINE&step=3m4a70MFS2yAIPmDVj5WOQ&stage=sJlJuVs4Rg2faxWLQKtPug&childStage=&stageExecId=)
- All existing functionality continues to work as expected