### PR TITLE
feat: [CI-17211]: Add source image support for cross-registry pushes in push-only mode

### DIFF
--- a/app.go
+++ b/app.go
@@ -417,8 +417,13 @@ func Run() {
 		},
 		cli.BoolFlag{
 			Name:   "push-only",
-			Usage:  "push only mode, skips build process",
+			Usage:  "skip build and only push images",
 			EnvVar: "PLUGIN_PUSH_ONLY",
+		},
+		cli.StringFlag{
+			Name:   "source-image",
+			Usage:  "source image to tag and push (format: repo:tag)",
+			EnvVar: "PLUGIN_SOURCE_IMAGE",
 		},
 		cli.StringFlag{
 			Name:   "source-tar-path",
@@ -526,6 +531,7 @@ func run(c *cli.Context) error {
 		BaseImageUsername: c.String("docker.baseimageusername"),
 		BaseImagePassword: c.String("docker.baseimagepassword"),
 		PushOnly:          c.Bool("push-only"),
+		SourceImage:       c.String("source-image"),
 		SourceTarPath:     c.String("source-tar-path"),
 		TarPath:           c.String("tar-path"),
 	}

--- a/docker.go
+++ b/docker.go
@@ -1068,7 +1068,7 @@ func (p Plugin) pushOnly() error {
 	for _, tag := range p.Build.Tags {
 		fullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
 
-		// Verify the image exists (it should since we just tagged it)
+		// Check if image exists in local daemon
 		if !imageExists(fullImageName) {
 			return fmt.Errorf("image %s not found, cannot push", fullImageName)
 		}

--- a/docker.go
+++ b/docker.go
@@ -115,6 +115,7 @@ type (
 		PushOnly          bool    // Push only mode, skips build process
 		SourceTarPath     string  // Path to Docker image tar file to load and push
 		TarPath           string  // Path to save Docker image as tar file
+		SourceImage       string  // Source image to push (optional)
 	}
 
 	Card []struct {
@@ -1002,12 +1003,72 @@ func (p Plugin) pushOnly() error {
 		}
 	}
 
-	// For each tag, verify image exists and push
+	// Check if source image is specified
+	sourceImageName := p.SourceImage
+	var sourceTags []string
+
+	if sourceImageName == "" {
+		// If no source image specified, use the repo (original behavior)
+		sourceImageName = p.Build.Repo
+		sourceTags = p.Build.Tags
+	} else {
+		// If source image is specified, check if it has a tag
+		parts := strings.Split(sourceImageName, ":")
+		if len(parts) > 1 {
+			sourceImageName = parts[0]
+			sourceTags = []string{parts[1]}
+		} else {
+			// Default to "latest" if no tag specified
+			sourceTags = []string{"latest"}
+		}
+		fmt.Printf("Using source image: %s with tag(s): %s\n", sourceImageName, strings.Join(sourceTags, ", "))
+	}
+
+	// For each source tag and target tag combination
 	var digest string
+	taggedForPush := make(map[string]bool)
+
+	for _, sourceTag := range sourceTags {
+		sourceFullImageName := fmt.Sprintf("%s:%s", sourceImageName, sourceTag)
+
+		// Check if the source image exists in local daemon
+		if !imageExists(sourceFullImageName) {
+			fmt.Printf("Warning: Source image %s not found\n", sourceFullImageName)
+			// Continue to the next source tag if available, otherwise return error
+			if len(sourceTags) > 1 {
+				continue
+			}
+			return fmt.Errorf("source image %s not found, cannot push", sourceFullImageName)
+		}
+
+		// For each target tag, tag and push
+		for _, targetTag := range p.Build.Tags {
+			targetFullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, targetTag)
+
+			// Skip if source and target are identical
+			if sourceFullImageName == targetFullImageName {
+				fmt.Printf("Source and target image names are identical: %s\n", sourceFullImageName)
+			} else {
+				// Tag the source image with the target name
+				fmt.Printf("Tagging %s as %s\n", sourceFullImageName, targetFullImageName)
+				tagCmd := commandTag(Build{Name: sourceFullImageName}, targetFullImageName)
+				tagCmd.Stdout = os.Stdout
+				tagCmd.Stderr = os.Stderr
+				trace(tagCmd)
+				if err := tagCmd.Run(); err != nil {
+					return fmt.Errorf("failed to tag image %s as %s: %w", sourceFullImageName, targetFullImageName, err)
+				}
+			}
+
+			taggedForPush[targetFullImageName] = true
+		}
+	}
+
+	// Push all successfully tagged images
 	for _, tag := range p.Build.Tags {
 		fullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
 
-		// Check if image exists in local daemon
+		// Verify the image exists (it should since we just tagged it)
 		if !imageExists(fullImageName) {
 			return fmt.Errorf("image %s not found, cannot push", fullImageName)
 		}

--- a/docker.go
+++ b/docker.go
@@ -1051,7 +1051,7 @@ func (p Plugin) pushOnly() error {
 			} else {
 				// Tag the source image with the target name
 				fmt.Printf("Tagging %s as %s\n", sourceFullImageName, targetFullImageName)
-				tagCmd := commandTag(Build{Name: sourceFullImageName}, targetFullImageName)
+				tagCmd := exec.Command(dockerExe, "tag", sourceFullImageName, targetFullImageName)
 				tagCmd.Stdout = os.Stdout
 				tagCmd.Stderr = os.Stderr
 				trace(tagCmd)


### PR DESCRIPTION
This PR enhances the push-only mode by adding support for cross-registry image distribution:

Changes:
- Added `source_image` parameter to specify a local image to tag and push
- Enhanced the `pushOnly()` function to automatically tag images for different registries
- Fixed Docker tag command formatting to handle cross-registry image names correctly
- Added proper error handling and logging for the tagging process

Use Case: This improves the build-once-push-many workflow pattern, enabling users to:
- Build an image once with one plugin instance
- Push the same image to multiple registries (ECR, GAR, etc.) in parallel using push-only mode
- Avoid rebuilding the same image for each registry

Testing:
- golden-buildx-build-once-push-many: [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/goldenbuildxbuildoncepushmany/deployments/uWlsljR-T-efYoHLXH0UoQ/pipeline?storeType=INLINE)
- golden-buildx-push-only-with-tar: [K8S](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/goldenbuildxpushonlywithtar/executions/iiGfTe0TRWCrUUt_DkMf2Q/pipeline?storeType=INLINE&step=RK41S4SARv6lzUNpMhR01Q&stage=-uUtsLMmSnG0IHtvVCFeKA&childStage=&stageExecId=), [Cloud](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/goldenbuildxpushonlywithtar/executions/Jmpfh7f4TGO9PyC03b81Jw/pipeline?storeType=INLINE)
- golden-buildx-push-only (with Background Dind Step and daemon_off true): [K8S](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/goldenbuildxpushonly/executions/T8tE5Y4YTyKFSEpj0oM6kw/pipeline?storeType=INLINE), [Cloud](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/goldenbuildxpushonly/executions/XX7_YBEfQyO08cdbERG_iQ/pipeline?storeType=INLINE)