### PR TITLE
feat: [CI-17379]: Add PLUGIN_BUILDX_OPTIONS_SEMICOLON for comma-containing values

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ envVariables:
   PLUGIN_BUILDX_OPTIONS: "--provenance=false, --platform=linux/amd64"
 ```
 
+#### For options with comma values
+
+If you need to pass options that contain commas in their values (like `--output=type=tar,dest=image.tar`), use the PLUGIN_BUILDX_OPTIONS_SEMICOLON environment variable with semicolons (`;`) as separators:
+
+```console
+envVariables:
+  PLUGIN_BUILDX_OPTIONS_SEMICOLON: "--platform=linux/amd64,linux/arm64;--provenance=false;--output=type=tar,dest=image.tar"
+```
+
 ## Developer Notes
 
 - When updating the base image, you will need to update for each architecture and OS.

--- a/app.go
+++ b/app.go
@@ -415,6 +415,11 @@ func Run() {
 			Usage:  "additional options to pass directly to the buildx command",
 			EnvVar: "PLUGIN_BUILDX_OPTIONS",
 		},
+		cli.StringFlag{
+			Name:   "buildx-options-semicolon",
+			Usage:  "additional options to pass directly to the buildx command, separated by semicolons",
+			EnvVar: "PLUGIN_BUILDX_OPTIONS_SEMICOLON",
+		},
 		cli.BoolFlag{
 			Name:   "push-only",
 			Usage:  "skip build and only push images",
@@ -497,6 +502,7 @@ func run(c *cli.Context) error {
 			HarnessSelfHostedS3SecretKey: c.String("harness-self-hosted-s3-secret-key"),
 			HarnessSelfHostedGcpJsonKey:  c.String("harness-self-hosted-gcp-json-key"),
 			BuildxOptions:                c.StringSlice("buildx-options"),
+			BuildxOptionsSemicolon:       c.String("buildx-options-semicolon"),
 		},
 		Daemon: Daemon{
 			Registry:         c.String("docker.registry"),

--- a/docker.go
+++ b/docker.go
@@ -95,6 +95,7 @@ type (
 		HarnessSelfHostedS3SecretKey string   // Harness self-hosted s3 secret key
 		HarnessSelfHostedGcpJsonKey  string   // Harness self hosted gcp json region
 		BuildxOptions                []string // Generic buildx options passed directly to the buildx command
+		BuildxOptionsSemicolon       string   // Buildx options separated by semicolons instead of commas
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -625,6 +626,14 @@ func commandBuildx(build Build, builder Builder, dryrun bool, metadataFile strin
 	}
 	if len(build.BuildxOptions) > 0 {
 		args = append(args, build.BuildxOptions...)
+	}
+	if build.BuildxOptionsSemicolon != "" {
+		splitOptions := strings.Split(build.BuildxOptionsSemicolon, ";")
+		for _, opt := range splitOptions {
+			if opt = strings.TrimSpace(opt); opt != "" {
+				args = append(args, opt)
+			}
+		}
 	}
 	args = append(args, build.Context)
 	if metadataFile != "" {

--- a/docker_test.go
+++ b/docker_test.go
@@ -207,6 +207,32 @@ func TestCommandBuildx(t *testing.T) {
 				"--metadata-file /tmp/metadata.json",
 			),
 		},
+		{
+			name: "buildx options with semicolon delimiter",
+			build: Build{
+				Name:                 "plugins/drone-docker:latest",
+				Dockerfile:           "Dockerfile",
+				Context:              ".",
+				Repo:                 "plugins/drone-docker",
+				Tags:                 []string{"latest"},
+				BuildxOptionsSemicolon: "--platform=linux/amd64,linux/arm64;--provenance=false;--output=type=tar,dest=image.tar",
+			},
+			want: exec.Command(
+				dockerExe,
+				"buildx",
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				"--push",
+				"--platform=linux/amd64,linux/arm64",
+				"--provenance=false",
+				"--output=type=tar,dest=image.tar",
+				".",
+			),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
When using `PLUGIN_BUILDX_OPTIONS` with Docker buildx options that contain commas in their values (such as `--output=type=tar,dest=image.tar`), the commas were incorrectly interpreted as separators between different options. This caused the command to be malformed and fail.

For example:
```
--provenance=false,--output=type=tar,dest=image.tar
```
Was incorrectly processed as:
```
--provenance=false
--output=type=tar
dest=image.tar  // Invalid argument!
```
#### Solution
- Added new env var `PLUGIN_BUILDX_OPTIONS_SEMICOLON` that uses semicolons as delimiters
- Kept original `PLUGIN_BUILDX_OPTIONS` for backward compatibility

#### Usage
Users can now pass buildx options with semicolons as separators:
```
PLUGIN_BUILDX_OPTIONS_SEMICOLON: "--platform=linux/amd64,linux/arm64;--provenance=false;--output=type=tar,dest=image.tar"
```
This ensures that commas within option values (like in `--platform=linux/amd64,linux/arm64` or `--output=type=tar,dest=image.tar`) are preserved correctly.

#### Testing
Added unit test to verify processing of semicolon-delimited options.

```
go test -v -run="TestCommandBuildx/buildx_options_with_semicolon_delimiter"
=== RUN   TestCommandBuildx
=== RUN   TestCommandBuildx/buildx_options_with_semicolon_delimiter
--- PASS: TestCommandBuildx (0.00s)
    --- PASS: TestCommandBuildx/buildx_options_with_semicolon_delimiter (0.00s)
PASS
ok      github.com/drone-plugins/drone-buildx   0.510s
```