### PR TITLE
feat: [CI-16559]: golang version up to 1.23 and docker base image up

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ platform:
 
 steps:
   - name: vet
-    image: golang:1.22
+    image: golang:1.23
     commands:
       - go vet ./...
     environment:
@@ -22,7 +22,7 @@ steps:
         path: /go
 
   - name: test
-    image: golang:1.22
+    image: golang:1.23
     commands:
       - go test -cover ./...
     environment:
@@ -55,7 +55,7 @@ platform:
 
 steps:
  - name: go build
-   image: golang:1.22
+   image: golang:1.23
    environment:
      CGO_ENABLED: 0
    commands:
@@ -98,7 +98,7 @@ platform:
 
 steps:
  - name: go build
-   image: golang:1.22
+   image: golang:1.23
    environment:
      CGO_ENABLED: 0
    commands:
@@ -141,7 +141,7 @@ platform:
 
 steps:
  - name: build-push
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-docker ./cmd/drone-docker'
    environment:
@@ -152,7 +152,7 @@ steps:
          - tag
 
  - name: build-tag
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-docker ./cmd/drone-docker'
    environment:
@@ -162,7 +162,7 @@ steps:
        - tag
 
  - name: executable
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - ./release/linux/amd64/drone-docker --help
 
@@ -211,7 +211,7 @@ platform:
 
 steps:
  - name: build-push
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-docker ./cmd/drone-docker'
    environment:
@@ -222,7 +222,7 @@ steps:
          - tag
 
  - name: build-tag
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-docker ./cmd/drone-docker'
    environment:
@@ -232,7 +232,7 @@ steps:
        - tag
 
  - name: executable
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - ./release/linux/arm64/drone-docker --help
 
@@ -316,7 +316,7 @@ platform:
 
 steps:
  - name: build-push
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-heroku ./cmd/drone-heroku'
    environment:
@@ -326,7 +326,7 @@ steps:
        exclude:
          - tag
  - name: build-tag
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-heroku ./cmd/drone-heroku'
    environment:
@@ -380,7 +380,7 @@ platform:
 
 steps:
  - name: build-push
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-heroku ./cmd/drone-heroku'
    environment:
@@ -390,7 +390,7 @@ steps:
        exclude:
          - tag
  - name: build-tag
-   image: golang:1.22
+   image: golang:1.23
    commands:
      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-heroku ./cmd/drone-heroku'
    environment:
@@ -475,7 +475,7 @@ pool:
 steps:
   - name: build
     pull: always
-    image: golang:1.22
+    image: golang:1.23
     commands:
       - GOOS=linux   GOARCH=amd64   go build -ldflags "-s -w" -a -tags netgo -o release/drone-buildx-linux-amd64 ./cmd/drone-docker
       - GOOS=linux   GOARCH=arm64   go build -ldflags "-s -w" -a -tags netgo -o release/drone-buildx-linux-arm64 ./cmd/drone-docker

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -33,7 +33,7 @@ pipeline:
                   name: Vet
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.22
+                    image: golang:1.23
                     shell: Sh
                     command: go vet ./...
               - step:
@@ -42,7 +42,7 @@ pipeline:
                   name: Test
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.22
+                    image: golang:1.23
                     shell: Sh
                     command: go test -cover ./...
     - parallel:
@@ -70,7 +70,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -150,7 +150,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -230,7 +230,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -310,7 +310,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -384,7 +384,7 @@ pipeline:
                       identifier: Build_Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -466,7 +466,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           # force go modules
@@ -551,7 +551,7 @@ pipeline:
                       name: Build Binaries
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22
+                        image: golang:1.23
                         shell: Sh
                         command: |-
                           GOOS=linux   GOARCH=amd64   go build -ldflags "-s -w" -a -tags netgo -o release/drone-buildx-linux-amd64 ./cmd/drone-docker

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:27.3.1-dind
+FROM docker:28.1.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
@@ -7,7 +7,7 @@ ENV BUILDKIT_PROGRESS=plain
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 ENV PLUGIN_BUILDKIT_ASSETS_DIR=/buildkit
 
-ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.18.0/buildx-v0.18.0.linux-amd64
+ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-amd64
 
 RUN mkdir -p $HOME/.docker/cli-plugins && \
     wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL && \

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:27.3.1-dind
+FROM arm64v8/docker:28.1.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
@@ -7,7 +7,7 @@ ENV BUILDKIT_PROGRESS=plain
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 ENV PLUGIN_BUILDKIT_ASSETS_DIR=/buildkit
 
-ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.18.0/buildx-v0.18.0.linux-arm64
+ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-amd64
 
 RUN mkdir -p $HOME/.docker/cli-plugins && \
     wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL && \

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,11 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.22
+go 1.23.0
+
+toolchain go1.24.2

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Upgrading golang and docker image
Before:
https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/1YaIEZalTcm-OKZ5EXCxFg/pipeline

Fix
https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/mWNcGvSCTd6O1oPcbMONeA/pipeline?step=CANFqKTUR4WX1_8vVSnOFQ&stage=qL0r2EvbSI-B8o5T-G90pA&childStage=&stageExecId=