### PR TITLE
feat: [CI-18552]: add Docker Buildx Bake support with multi-registry capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,6 @@ envVariables:
   PLUGIN_BAKE_OPTIONS: "--set=*.platform=linux/amd64"
 ```
 
-Bake with metadata output
-```yaml
-envVariables:
-  PLUGIN_BAKE_FILE: docker-bake.hcl
-  PLUGIN_BAKE_OPTIONS: "web"
-  PLUGIN_METADATA_FILE: "/tmp/metadata.json"
-```
-
 ## Developer Notes
 
 - When updating the base image, you will need to update for each architecture and OS.

--- a/app.go
+++ b/app.go
@@ -430,6 +430,16 @@ func Run() {
 			Usage:  "additional options to pass directly to the buildx command, separated by semicolons",
 			EnvVar: "PLUGIN_BUILDX_OPTIONS_SEMICOLON",
 		},
+		cli.StringFlag{
+			Name:   "bake-file",
+			Usage:  "Buildx Bake definition file (HCL/JSON/Compose). When set, plugin runs docker buildx bake",
+			EnvVar: "PLUGIN_BAKE_FILE",
+		},
+		cli.StringFlag{
+			Name:   "bake-options",
+			Usage:  "Semicolon-delimited extra bake CLI args and/or target names",
+			EnvVar: "PLUGIN_BAKE_OPTIONS",
+		},
 		cli.BoolFlag{
 			Name:   "push-only",
 			Usage:  "skip build and only push images",
@@ -515,6 +525,8 @@ func run(c *cli.Context) error {
 			HarnessSelfHostedGcpJsonKey:  c.String("harness-self-hosted-gcp-json-key"),
 			BuildxOptions:                c.StringSlice("buildx-options"),
 			BuildxOptionsSemicolon:       c.String("buildx-options-semicolon"),
+			BakeFile:                     c.String("bake-file"),
+			BakeOptions:                  c.String("bake-options"),
 		},
 		Daemon: Daemon{
 			Registry:         c.String("docker.registry"),

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -7,7 +7,7 @@ ENV BUILDKIT_PROGRESS=plain
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 ENV PLUGIN_BUILDKIT_ASSETS_DIR=/buildkit
 
-ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-amd64
+ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-arm64
 
 RUN mkdir -p $HOME/.docker/cli-plugins && \
     wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL && \


### PR DESCRIPTION
Adds opt-in Docker Buildx Bake support for high-level builds and multi-registry pushes, while maintaining full backward compatibility.

Key Features:

  - Bake Mode: Activated via PLUGIN_BAKE_FILE - runs docker buildx bake instead of docker buildx build
  - Multi-Registry Push: Single bake command pushes to multiple registries in parallel
  - Flexible Options: PLUGIN_BAKE_OPTIONS supports targets, --set overrides, and additional flags (semicolon-delimited)
  - Enhanced Config: PLUGIN_CONFIG now accepts file paths OR JSON content (uses os.Stat detection)

New Inputs:

  - PLUGIN_BAKE_FILE: Path to bake definition file (HCL/JSON/Compose)
  - PLUGIN_BAKE_OPTIONS: Semicolon-delimited bake CLI flags and targets

Backward Compatibility:

  - ✅ All existing functionality unchanged when PLUGIN_BAKE_FILE not set
  - ✅ PLUGIN_CONFIG enhancement maintains JSON content support
  - ✅ Bake and push-only modes are mutually exclusive (with validation)

Benefits:

  - Simplified Pipelines: Replace multiple build+push steps with single bake step
  - Atomic Multi-Registry: All registries get identical image with same digest
  - Better Performance: Parallel pushes handled by buildx
  - Declarative Config: Build configuration in version-controlled bake files

Usage Example
```
  settings:
    bake_file: docker-bake.hcl
    config: /path/to/docker-config.json
    bake_options: "web;api;--progress=plain"
```

Fixes: Enables efficient multi-registry workflows and advanced BuildKit features through bake files.