### PR TITLE
fix: [CI-21415]: remediate CVE-2025-15558 - upgrade base image to docker:29.3.0-dind

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:28.1.1-dind
+FROM docker:29.3.0-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
@@ -7,7 +7,7 @@ ENV BUILDKIT_PROGRESS=plain
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 ENV PLUGIN_BUILDKIT_ASSETS_DIR=/buildkit
 
-ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-amd64
+ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.32.1/buildx-v0.32.1.linux-amd64
 
 RUN mkdir -p $HOME/.docker/cli-plugins && \
     wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL && \

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:28.1.1-dind
+FROM arm64v8/docker:29.3.0-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
@@ -7,7 +7,7 @@ ENV BUILDKIT_PROGRESS=plain
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 ENV PLUGIN_BUILDKIT_ASSETS_DIR=/buildkit
 
-ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.23.0/buildx-v0.23.0.linux-arm64
+ARG BUILDX_URL=https://github.com/docker/buildx/releases/download/v0.32.1/buildx-v0.32.1.linux-arm64
 
 RUN mkdir -p $HOME/.docker/cli-plugins && \
     wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL && \


### PR DESCRIPTION
## Vulnerability Remediation: `plugins/buildx:1.3.15`

**JIRA:** [CI-21415](https://harness.atlassian.net/browse/CI-21415)
**Test image scanned:** `vinayakharness/buildx-test:buildx-1.3.16--debug`
**Scanner:** Prisma Cloud (Twistlock) via Harness STO

---

### OnDemand Scan Results

| Scan | Image | Link |
|------|-------|------|
| Baseline (before) | `plugins/buildx:1.3.15` | [View scan](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/sto/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/Dz_q-0zBSgyQQtHHl4CSMA/pipeline) |
| Test (after) | `vinayakharness/buildx-test:buildx-1.3.16--debug` | [View scan](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/sto/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/ZPRcXWQwTHyzN9Dewo3WTw/pipeline) |

---

### Vulnerability Delta

| Severity | Before (`1.3.15`) | After (`buildx-1.3.16--debug`) | Change |
|----------|:-----------------:|:------------------------------:|:------:|
| Critical | 3 | 0 | **-3** |
| High | 16 | 2 | **-14** |
| Medium | 15 | 3 | **-12** |
| Low | 5 | 0 | **-5** |
| **Total** | **46** | **6** | **-40 (87% reduction)** |

---

### CVE Status

| CVE | Package | Before | After | Required | Status | Reason |
|-----|---------|--------|-------|----------|--------|--------|
| CVE-2025-15558 | github.com/docker/cli | v28.0.4 | v29.3.0 | v29.2.0+ | Resolved | Base image upgraded to docker:29.3.0-dind |

---

### Changes Made

| File | Change |
|------|--------|
| `docker/docker/Dockerfile.linux.amd64` | `docker:28.1.1-dind` -> `docker:29.3.0-dind` |
| `docker/docker/Dockerfile.linux.arm64` | `arm64v8/docker:28.1.1-dind` -> `arm64v8/docker:29.3.0-dind` |
| `docker/docker/Dockerfile.linux.amd64` | buildx binary `v0.23.0` -> `v0.32.1` |
| `docker/docker/Dockerfile.linux.arm64` | buildx binary `v0.23.0` -> `v0.32.1` |

---

> [!WARNING]
> **Major version upgrade included - sanity testing required**
>
> The base image was upgraded across a major version boundary (docker:28 -> docker:29) which may contain breaking changes.
>
> Before merging, please:
> 1. Deploy the new image to a QA or staging environment
> 2. Run the full CI pipeline sanity suite against it
> 3. Verify plugin-specific behaviour (build outputs, caching, auth flows, DinD socket) is unchanged
> 4. Check the Docker 29.x changelog for breaking changes before approving

[CI-21415]: https://harness.atlassian.net/browse/CI-21415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ