### PR TITLE
fix: [CI-21697] fix EOL and security vulnerabilities

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -384,8 +384,10 @@ pipeline:
                       identifier: Build_Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.26
+                        image: golang:1.24.3
                         shell: Sh
+                        envVariables:
+                          GOTOOLCHAIN: go1.26.0
                         command: |-
                           # force go modules
                           export GOPATH=""

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -384,10 +384,8 @@ pipeline:
                       identifier: Build_Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.3
+                        image: golang:1.23.0
                         shell: Sh
-                        envVariables:
-                          GOTOOLCHAIN: go1.26.0
                         command: |-
                           # force go modules
                           export GOPATH=""
@@ -402,6 +400,8 @@ pipeline:
                           GOOS=windows
 
                           go build -buildvcs=false -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
+                        envVariables:
+                          GOTOOLCHAIN: go1.26.0
                   - step:
                       type: Plugin
                       name: Build and Push on Tag

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -33,7 +33,7 @@ pipeline:
                   name: Vet
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.24.11
+                    image: golang:1.26
                     shell: Sh
                     command: go vet ./...
               - step:
@@ -42,7 +42,7 @@ pipeline:
                   name: Test
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.24.11
+                    image: golang:1.26
                     shell: Sh
                     command: go test -cover ./...
     - parallel:
@@ -70,7 +70,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.11
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -150,7 +150,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.11
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -230,7 +230,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.11
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -310,7 +310,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.11
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -384,7 +384,7 @@ pipeline:
                       identifier: Build_Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.23.0
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -399,7 +399,7 @@ pipeline:
                           # linux
                           GOOS=windows
 
-                          go build -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
+                          go build -buildvcs=false -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
                   - step:
                       type: Plugin
                       name: Build and Push on Tag
@@ -468,7 +468,7 @@ pipeline:
                       name: Build Binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.23.0
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           # force go modules
@@ -483,7 +483,7 @@ pipeline:
                           # windows
                           GOOS=windows
 
-                          go build -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
+                          go build -buildvcs=false -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
                   - step:
                       type: Plugin
                       name: Build and Push on Tag
@@ -555,7 +555,7 @@ pipeline:
                       name: Build Binaries
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.24.11
+                        image: golang:1.26
                         shell: Sh
                         command: |-
                           GOOS=linux   GOARCH=amd64   go build -ldflags "-s -w" -a -tags netgo -o release/drone-buildx-linux-amd64 ./cmd/drone-docker

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:28.1.1-dind
+FROM docker:29.3.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.24.11
-
-toolchain go1.25.5
+go 1.26


### PR DESCRIPTION
- Update Go version from 1.24.11 (EOL) to 1.26
- Remove explicit toolchain go1.25.5 directive
- Update base Docker image from docker:28.1.1-dind to docker:29.3.1-dind

Fixes:
- stdlib go1.24.11/go1.24.3/go1.23.8: EOL 2026-02-11
- zfs 2.2.7-r0: EOL 2025-12-18
- openssl 3.3.3-r0: Approaching EOL 2026-04-09
- containerd/v2 v2.0.4/v2.0.5/v2.1.1: GHSA-cxfp-7pvr-95ff, GHSA-m6hq-p25p-ffr2, GHSA-pwhc-rpq9-4c8w, GO-2025-4100, GO-2025-4108
- containernetworking/plugins v1.6.2: GHSA-jv3w-x3r3-g6rm, GO-2025-4222

AI-Session-Id: b372d4bb-7813-4e5b-8342-23968a0f0e23
AI-Tool: claude-code
AI-Model: global.anthropic.claude-sonnet-4-6


