### PR TITLE
feat: [CI-22341]: bump buildkit to 1.0.17

### DIFF
--- a/buildkit/version.json
+++ b/buildkit/version.json
@@ -1,3 +1,3 @@
 {
-    "buildkit_version": "harness/buildkit:1.0.16"
+    "buildkit_version": "harness/buildkit:1.0.17"
 }


### PR DESCRIPTION
## Summary
- Bumps `buildkit/version.json` from `harness/buildkit:1.0.16` → `harness/buildkit:1.0.17`

## Release pipeline
https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/ci/orgs/PROD/projects/CI/pipelines/Buildkit/executions/dpyXvPoWR5KK_lD1hZUZzw/pipeline

## Test plan
- [ ] CI build pulls and embeds the new `harness/buildkit:1.0.17` image via `buildkit/release.sh`
- [ ] Plugin runs successfully against the loaded buildkit tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)