### PR TITLE
fix: [CI-22663]: revert the version of docker-dind with security patch

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:29.3.1-dind
+FROM docker:28.5.2-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:28.1.1-dind
+FROM arm64v8/docker:28.5.2-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
<img width="1669" height="989" alt="Screenshot 2026-05-12 at 4 20 12 PM" src="https://github.com/user-attachments/assets/92d890ff-40e4-4634-b90a-da4663c25554" />


Reverted the docker dind version with security fixes, this will again add some EoL packages issue, but since we do not have fix from docker here, we will continue.


  In v1.3.17, the base Docker image for the buildx plugin was upgraded from docker:28.1.1-dind to docker:29.3.1-dind as part of CI-21697 (EOL/security vulnerability fixes). Docker Engine 29 changed the default
  storage backend to use the containerd overlayfs snapshotter instead of Docker's legacy overlay2 graph driver.

  In certain Docker-in-Docker environments  specifically where the host filesystem or container runtime doesn't fully support nested overlay mounts with the containerd snapshotter,  this causes the overlay
  mount to fail with EINVAL (invalid argument). The failure is environment-dependent: it triggers when the backing filesystem characteristics inside the container don't satisfy the containerd snapshotter's
  requirements (e.g., userxattr detection failures, specific kernel/storage driver combinations)