### PR TITLE
fix: [CI-23216]: bump docker:dind to 29.6.2 (containerd 2.2.6) + buildx v0.35.0 — CVE remediation

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:28.5.2-dind
+FROM docker:29.6.2-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:28.5.2-dind
+FROM arm64v8/docker:29.6.2-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
## Vulnerability Remediation: harnesssecure/buildx-ecr

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-23216](https://harness.atlassian.net/browse/CI-23216)
**Test image:** `vinayakharness/buildx-ecr-test:buildx-ecr-1.5.1--debug`

> **Refresh of existing PR #110.** This branch was rebased onto latest `master` (which already carries buildx `v0.35.0` from CI-23807) and the `docker:dind` base was bumped further: `28.5.2` → **`29.6.2`** (was `29.6.0` in the prior revision of this PR). `docker:29.6.2-dind` ships **containerd v2.2.6**, clearing the residual `containerd ≥2.2.5` HIGH/CRIT class that `29.6.0` (containerd 2.2.4) left open.

**OnDemand scanner runs (Harness https://harness0.harness.io):**
- Baseline: [qvZKRNbTSMqEnDvSYSY6Gw](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/qvZKRNbTSMqEnDvSYSY6Gw/pipeline) — `harnesssecure/buildx-ecr:1.5`
- After:    [6Pg8JQweTkCaFpOq1yJyWA](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/6Pg8JQweTkCaFpOq1yJyWA/pipeline) — `vinayakharness/buildx-ecr-test:buildx-ecr-1.5.1--debug`

---

### Summary

buildx-ecr is a thin wrapper around `plugins/buildx`; all of its CVEs originate in the parent `drone-buildx` repo, so the fix is applied there and cascades to ecr/gcr/gar/acr. `master` already carried buildx `v0.35.0` (from CI-23807); this refresh additionally bumps the dind base `28.5.2 → 29.6.2`, which pulls in Alpine 3.24.1 (openssl 3.5.7), Docker Engine 29.6.2, and **containerd v2.2.6**. Both scanners confirm a large reduction: Trivy total **685 → 127 (-81%)**, CRITICAL **17 → 3 (-82%)**; OnDemand total **56 → 28 (-50%)**, CRITICAL **3 → 1**. The 3 residual Trivy criticals are all `google.golang.org/grpc v1.78.0` (needs 1.79.3) compiled into the containerd binaries; upstream containerd 2.2.6 still bundles grpc 1.78.0, so this class is **upstream-pending** and cannot be closed by a Dockerfile tag bump. Recommendation: **REVIEW** — ship this as the improved remediation over the prior #110 revision; the remaining classes track upstream docker/containerd/buildkit Go rebuilds.

---

### CVE Delta — Trivy (local scan)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 17     | 3     | -14    |
| High     | 293    | 61    | -232   |
| Medium   | 284    | 39    | -245   |
| Low      | 71     | 4     | -67    |
| Total    | 685    | 127   | -558   |

### CVE Delta — Harness OnDemand (Prisma Cloud)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 3      | 1     | -2     |
| High     | 23     | 7     | -16    |
| Medium   | 29     | 20    | -9     |
| Low      | 1      | 0     | -1     |
| Info     | 0      | 0     | 0      |
| Total    | 56     | 28    | -28    |

---

### Per-Ticket CVE Status

#### CI-23216 — [P2: Security Vulnerability Fixes - harnesssecure/buildx-ecr](https://harness.atlassian.net/browse/CI-23216)

**Summary:** The ticket reports aggregate posture only (2 CRIT / 28 HIGH / 31 MED / 3 LOW, 64 unique) with no explicit CVE list. CVEs come entirely from the parent `plugins/buildx` image (dind base + wget-installed buildx). Fixing in `drone-buildx` (buildx v0.35.0 already on master + dind bump to 29.6.2) cascades to the ecr variant. Bulk of criticals/highs cleared; residuals are upstream-pending Go-dependency classes.

| Class | Package | Before | After | Required | Status | Reason |
|-------|---------|--------|-------|----------|--------|--------|
| openssl | openssl / libssl3 / libcrypto3 | 3.5.4-r0 (alpine 3.22.2) | 3.5.7-r0 (alpine 3.24.1) | 3.5.6-r0 | ✅ Resolved | dind 29.6.2 ships Alpine 3.24.1 |
| stdlib (CVE-2025-68121) | Go stdlib in docker/buildx binaries | v1.24.x | mixed (some fixed, some v1.26.x) | 1.25.7+ | ⚠️ Partial | newer base binaries; some still on pre-fix Go builds |
| containerd | containerd/v2 | 2.2.4 | 2.2.6 | 2.2.5+ | ✅ Resolved | dind 29.6.2 → containerd 2.2.6 (base binary) |
| grpc (CVE-2026-33186) | google.golang.org/grpc | v1.72.2 / v1.74.2 | v1.78.0 | 1.79.3 | ❌ Blocked | upstream containerd 2.2.6 still bundles grpc 1.78.0 |
| golang.org/x/net | golang.org/x/net | v0.31.x | v0.35.0 | 0.53.0+ | ⚠️ Partial | improved via newer base; full fix needs upstream rebuild |

---

### Changes Made

| File | Change |
|------|--------|
| docker/docker/Dockerfile.linux.amd64 | `FROM docker:28.5.2-dind` → `FROM docker:29.6.2-dind` |
| docker/docker/Dockerfile.linux.arm64 | `FROM arm64v8/docker:28.5.2-dind` → `FROM arm64v8/docker:29.6.2-dind` |

*(buildx `v0.35.0` was already present on `master` via CI-23807; no further change needed there.)*

**Version selection rationale:**
- `docker:29.6.2-dind` is the minimum same-registry (`library/docker`) patch tag that ships **containerd v2.2.6** (≥2.2.5, clearing the residual containerd class) and **Alpine 3.24.1 / openssl 3.5.7** (≥3.5.6-r0). It improves on the prior #110 revision's `29.6.0` (containerd 2.2.4, still vulnerable). Registry/namespace unchanged — tag-only bump.

---

### ⚠️ Same-registry note — upstream-pending residuals

The remaining HIGH/CRITICAL findings are Go dependencies (`grpc`, `golang.org/x/net`, `stdlib`) statically compiled into the upstream `docker`, `containerd`, `buildkit`, and `docker-buildx` binaries shipped inside `docker:29.6.2-dind`. They cannot be remediated by a Dockerfile tag bump and require the docker/containerd/buildkit projects to publish rebuilt binaries (e.g. grpc ≥1.79.3). No newer same-registry `docker:*-dind` tag currently clears them. Tracking for the next base bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CI-23216]: https://harness.atlassian.net/browse/CI-23216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ