### PR TITLE
feat: [CI-23744]: forward standard proxy vars and HARNESS_CA_PATH to buildx driver

### DIFF
--- a/buildx.go
+++ b/buildx.go
@@ -25,15 +25,8 @@ func cmdSetupBuildx(builder Builder, driverOpts []string, inheritAuth bool) *exe
 	for _, opt := range driverOpts {
 		args = append(args, "--driver-opt", opt)
 	}
-	if harnessHttpProxy := os.Getenv("HARNESS_HTTP_PROXY"); harnessHttpProxy != "" {
-		args = append(args, "--driver-opt", fmt.Sprintf("env.http_proxy=%s", harnessHttpProxy))
-
-		if harnessHttpsProxy := os.Getenv("HARNESS_HTTPS_PROXY"); harnessHttpsProxy != "" {
-			args = append(args, "--driver-opt", fmt.Sprintf("env.https_proxy=%s", harnessHttpsProxy))
-		}
-
-		args = append(args, "--driver-opt", "network=host")
-	}
+	args = appendProxyDriverOpts(args)
+	args = appendHarnessCADriverOpts(args)
 
 	if builder.RemoteConn != "" && builder.Driver == remoteDriver {
 		args = append(args, builder.RemoteConn)
@@ -88,4 +81,60 @@ func cmdInspectBuildx(name string) *exec.Cmd {
 func cmdRemoveBuildx(name string) *exec.Cmd {
 	args := []string{"buildx", "rm", name}
 	return exec.Command(dockerExe, args...)
+}
+
+// appendProxyDriverOpts forwards proxy env into the buildx docker-container
+// builder. Uses getProxyValue precedence: standard -> uppercase -> HARNESS_.
+// no_proxy values with commas are quoted so buildx's CSV parser does not split them.
+func appendProxyDriverOpts(args []string) []string {
+	httpProxy := getProxyValue("http_proxy")
+	httpsProxy := getProxyValue("https_proxy")
+	noProxy := getProxyValue("no_proxy")
+
+	if httpProxy == "" && httpsProxy == "" && noProxy == "" {
+		return args
+	}
+
+	if httpProxy != "" {
+		args = append(args, "--driver-opt", fmt.Sprintf("env.http_proxy=%s", httpProxy))
+	}
+	if httpsProxy != "" {
+		args = append(args, "--driver-opt", fmt.Sprintf("env.https_proxy=%s", httpsProxy))
+	}
+	if noProxy != "" {
+		opt := fmt.Sprintf("env.no_proxy=%s", noProxy)
+		// buildx splits --driver-opt on commas unless the k=v pair is quoted.
+		if strings.Contains(noProxy, ",") {
+			opt = `"` + opt + `"`
+		}
+		args = append(args, "--driver-opt", opt)
+	}
+	if httpProxy != "" || httpsProxy != "" {
+		args = append(args, "--driver-opt", "network=host")
+	}
+	return args
+}
+
+// appendHarnessCADriverOpts forwards HARNESS_CA_PATH (and file content when
+// readable) into the BuildKit container. A host path alone is not visible
+// inside the builder filesystem, so content is passed via env.HARNESS_CA_CERT
+// for the custom BuildKit entrypoint to install into the trust store.
+func appendHarnessCADriverOpts(args []string) []string {
+	caPath := os.Getenv("HARNESS_CA_PATH")
+	if caPath == "" {
+		return args
+	}
+
+	args = append(args, "--driver-opt", fmt.Sprintf("env.HARNESS_CA_PATH=%s", caPath))
+	content, err := os.ReadFile(caPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: HARNESS_CA_PATH is set to '%s' but the file does not exist\n", caPath)
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: unable to read HARNESS_CA_PATH '%s': %v\n", caPath, err)
+		}
+		return args
+	}
+	args = append(args, "--driver-opt", fmt.Sprintf("env.HARNESS_CA_CERT=%s", string(content)))
+	return args
 }

--- a/buildx_test.go
+++ b/buildx_test.go
@@ -1,0 +1,133 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCmdSetupBuildx_ForwardsStandardProxyVars(t *testing.T) {
+	unsetProxyEnv(t)
+
+	t.Setenv("http_proxy", "http://proxy.example:8080")
+	t.Setenv("https_proxy", "http://proxy.example:8443")
+	t.Setenv("no_proxy", "localhost")
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver, Name: "test"}, nil, false)
+	args := cmd.Args
+
+	assertHasDriverOpt(t, args, "env.http_proxy=http://proxy.example:8080")
+	assertHasDriverOpt(t, args, "env.https_proxy=http://proxy.example:8443")
+	assertHasDriverOpt(t, args, "env.no_proxy=localhost")
+	assertHasDriverOpt(t, args, "network=host")
+}
+
+func TestCmdSetupBuildx_PrefersStandardProxyOverHarness(t *testing.T) {
+	unsetProxyEnv(t)
+
+	t.Setenv("http_proxy", "http://standard:8080")
+	t.Setenv("HARNESS_HTTP_PROXY", "http://harness:8080")
+	t.Setenv("https_proxy", "http://standard:8443")
+	t.Setenv("HARNESS_HTTPS_PROXY", "http://harness:8443")
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver}, nil, false)
+	args := cmd.Args
+
+	assertHasDriverOpt(t, args, "env.http_proxy=http://standard:8080")
+	assertHasDriverOpt(t, args, "env.https_proxy=http://standard:8443")
+	assertNotHasDriverOpt(t, args, "env.http_proxy=http://harness:8080")
+}
+
+func TestCmdSetupBuildx_FallsBackToHarnessProxy(t *testing.T) {
+	unsetProxyEnv(t)
+
+	t.Setenv("HARNESS_HTTP_PROXY", "http://harness:8080")
+	t.Setenv("HARNESS_HTTPS_PROXY", "http://harness:8443")
+	t.Setenv("HARNESS_NO_PROXY", "localhost")
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver}, nil, false)
+	args := cmd.Args
+
+	assertHasDriverOpt(t, args, "env.http_proxy=http://harness:8080")
+	assertHasDriverOpt(t, args, "env.https_proxy=http://harness:8443")
+	assertHasDriverOpt(t, args, "env.no_proxy=localhost")
+	assertHasDriverOpt(t, args, "network=host")
+}
+
+func TestCmdSetupBuildx_QuotesNoProxyWhenContainsCommas(t *testing.T) {
+	unsetProxyEnv(t)
+
+	t.Setenv("http_proxy", "http://proxy.example:8080")
+	t.Setenv("no_proxy", "localhost,127.0.0.1,.example.com")
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver}, nil, false)
+	args := cmd.Args
+
+	assertHasDriverOpt(t, args, `"env.no_proxy=localhost,127.0.0.1,.example.com"`)
+}
+
+func TestCmdSetupBuildx_ForwardsHarnessCAPathAndContent(t *testing.T) {
+	unsetProxyEnv(t)
+	t.Setenv("HARNESS_CA_PATH", "")
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "harness-ca.crt")
+	caContent := "-----BEGIN CERTIFICATE-----\nTESTCERT\n-----END CERTIFICATE-----\n"
+	if err := os.WriteFile(caPath, []byte(caContent), 0644); err != nil {
+		t.Fatalf("write ca file: %v", err)
+	}
+	t.Setenv("HARNESS_CA_PATH", caPath)
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver}, nil, false)
+	args := cmd.Args
+
+	assertHasDriverOpt(t, args, "env.HARNESS_CA_PATH="+caPath)
+	assertHasDriverOpt(t, args, "env.HARNESS_CA_CERT="+caContent)
+}
+
+func TestCmdSetupBuildx_OmitsCAWhenUnset(t *testing.T) {
+	unsetProxyEnv(t)
+	os.Unsetenv("HARNESS_CA_PATH")
+
+	cmd := cmdSetupBuildx(Builder{Driver: dockerContainerDriver}, nil, false)
+	args := cmd.Args
+
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--driver-opt" && strings.HasPrefix(args[i+1], "env.HARNESS_CA_") {
+			t.Fatalf("unexpected CA driver opt %q", args[i+1])
+		}
+	}
+}
+
+func unsetProxyEnv(t *testing.T) {
+	t.Helper()
+	keys := []string{
+		"http_proxy", "HTTP_PROXY", "HARNESS_HTTP_PROXY",
+		"https_proxy", "HTTPS_PROXY", "HARNESS_HTTPS_PROXY",
+		"no_proxy", "NO_PROXY", "HARNESS_NO_PROXY",
+		"HARNESS_CA_PATH",
+	}
+	for _, key := range keys {
+		os.Unsetenv(key)
+	}
+}
+
+func assertHasDriverOpt(t *testing.T, args []string, want string) {
+	t.Helper()
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--driver-opt" && args[i+1] == want {
+			return
+		}
+	}
+	t.Fatalf("missing --driver-opt %q in args: %v", want, args)
+}
+
+func assertNotHasDriverOpt(t *testing.T, args []string, unwanted string) {
+	t.Helper()
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--driver-opt" && args[i+1] == unwanted {
+			t.Fatalf("unexpected --driver-opt %q in args: %v", unwanted, args)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When a CI Build-and-Push step uses the `docker-container` buildx driver behind the Harness egress proxy (TLS-intercepting), base-image pulls fail because:

1. The BuildKit container does not inherit proxy environment variables from the host, so it attempts to dial registries directly and times out (`dial tcp <ip>:443: i/o timeout`)
2. Even when the proxy reaches the builder, it does not trust the Harness TLS-interception CA, failing with `x509: certificate signed by unknown authority`

This issue was observed at customer HNB (Huntington) on their JFrog/GAR base-image pulls behind the egress proxy.

## Root Cause

The drone-buildx plugin's `cmdSetupBuildx` function previously only forwarded `HARNESS_HTTP_PROXY` and `HARNESS_HTTPS_PROXY` to the buildx driver-opts, missing:
- Standard proxy variables (`http_proxy`, `https_proxy`, `no_proxy`)
- The `no_proxy` variable entirely
- The `HARNESS_CA_PATH` certificate needed for TLS-interception trust

The BuildKit container runs in an isolated filesystem and does not inherit host environment variables or files unless explicitly passed via `--driver-opt env.*`.

## Solution

### 1. Forward standard proxy variables to buildx driver

Added `appendProxyDriverOpts` function that:
- Honors standard proxy variables (`http_proxy`, `https_proxy`, `no_proxy`) with precedence: standard → uppercase → `HARNESS_*`
- Forwards all three proxy types as `--driver-opt env.*` options
- Handles comma-separated `no_proxy` values by quoting the entire `k=v` pair (buildx's CSV parser would otherwise split on commas)
- Sets `network=host` when any proxy is configured

### 2. Forward HARNESS_CA_PATH to buildx driver

Added `appendHarnessCADriverOpts` function that:
- Reads the certificate file from `HARNESS_CA_PATH` environment variable
- Forwards both the path (`env.HARNESS_CA_PATH`) and the file content (`env.HARNESS_CA_CERT`) as driver-opts
- The custom BuildKit image's entrypoint (separate repo: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/CI/repos/buildkit) will install this CA into the container trust store
- Best-effort with graceful warnings if the file is missing or unreadable

## Changes Made

- Refactored `cmdSetupBuildx` to call `appendProxyDriverOpts` and `appendHarnessCADriverOpts`
- Removed hardcoded `HARNESS_HTTP_PROXY` handling in favor of the new functions
- Added comprehensive test coverage in `buildx_test.go`:
  - Standard proxy variable forwarding
  - Precedence over `HARNESS_*` variants
  - Fallback to `HARNESS_*` when standard vars unset
  - Comma-separated `no_proxy` quoting
  - CA path and content forwarding
  - Graceful handling when CA unset

## Testing

All new tests pass:
```
✅ TestCmdSetupBuildx_ForwardsStandardProxyVars
✅ TestCmdSetupBuildx_PrefersStandardProxyOverHarness
✅ TestCmdSetupBuildx_FallsBackToHarnessProxy
✅ TestCmdSetupBuildx_QuotesNoProxyWhenContainsCommas
✅ TestCmdSetupBuildx_ForwardsHarnessCAPathAndContent
✅ TestCmdSetupBuildx_OmitsCAWhenUnset
```

## Related Issues/Logs

- JIRA: [CI-23744](https://harness.atlassian.net/browse/CI-23744)
- Customer: HNB (Huntington) egress proxy testing
- Companion fix: drone-docker plugin already handles `HARNESS_CA_PATH` for plain `docker` driver
- BuildKit image repo (entrypoint implementation): https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/CI/repos/buildkit

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-23744]: https://harness.atlassian.net/browse/CI-23744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ