### PR TITLE
[NEEDS-SCAN] fix: [CI-22906]: remediate CVE-2022-28948 - upgrade gopkg.in/yaml.v3 to v3.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.26

--- a/go.sum
+++ b/go.sum
@@ -73,3 +73,5 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Vulnerability Remediation: plugins/buildx

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-22906](https://harness.atlassian.net/browse/CI-22906)
**Test image:** `vinayakharness/buildx-test:buildx-1.3.25--debug`

**OnDemand scanner runs (Harness https://harness0.harness.io/):**
- Baseline: BLOCKED (NG_ACCESS_DENIED — token lacks `core_pipeline_execute` on `Ondemand_Vulnerability_Scanner`)
- After:    BLOCKED (same reason)

---

### Summary

`gopkg.in/yaml.v3` was pinned at `v3.0.0-20210107192922-496545a6307b` (a pre-release snapshot) in go.mod, which is older than the stable `v3.0.1` release that fixed CVE-2022-28948 (panic via infinite recursion on crafted YAML input). This PR upgrades the indirect dependency to `v3.0.1`. Trivy confirms CVE-2022-28948 is not present in the compiled `bin/drone-docker` binary in the test image (it is a test-only transitive dep via `testify`), so CVE counts are unchanged in the binary scan. The go.mod/go.sum fix is still necessary to remove the vulnerable module version from the dependency graph and SBOM. **Recommendation: WAIT** — OnDemand scanner evidence could not be collected (pipeline permission denied); PR is opened as DRAFT. A maintainer with pipeline access should trigger the OnDemand scan or approve after reviewing the Trivy results.

---

### CVE Delta — Trivy (local scan)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 15     | 15    | 0      |
| High     | 259    | 259   | 0      |
| Medium   | 242    | 242   | 0      |
| Low      | 69     | 69    | 0      |
| Total    | 585    | 585   | 0      |

> Note: CVE-2022-28948 (`gopkg.in/yaml.v3`) is not compiled into the `bin/drone-docker` binary — it is a test-only indirect dependency pulled in by `github.com/stretchr/testify@v1.7.0`. It therefore does not appear in the binary scan. The module upgrade removes the vulnerable version from the go.mod graph and SBOM.

### CVE Delta — Harness OnDemand (Prisma Cloud)

OnDemand scans could not be triggered: `NG_ACCESS_DENIED — Missing permission core_pipeline_execute on pipeline Ondemand_Vulnerability_Scanner`. Scan evidence is missing; see `[NEEDS-SCAN]` in the PR title.

---

### Per-Ticket CVE Status

#### CI-22906 — [High: CVE-2022-28948 gopkg.in/yaml.v3](https://harness.atlassian.net/browse/CI-22906)

**Summary:** `gopkg.in/yaml.v3` was pinned at the pre-release snapshot `v3.0.0-20210107192922-496545a6307b`. CVE-2022-28948 (panic via infinite recursion on crafted YAML) was fixed in `v3.0.1`. This dep is indirect, brought in via `github.com/stretchr/testify` (test use), and is not compiled into the production binary — Trivy does not detect it in the binary scan. The upgrade to `v3.0.1` removes the vulnerable version from the module graph.

| CVE | Package | Before | After | Required | Status | Reason |
|-----|---------|--------|-------|----------|--------|--------|
| CVE-2022-28948 | gopkg.in/yaml.v3 | v3.0.0-20210107192922-496545a6307b | v3.0.1 | v3.0.1+ | ✅ Resolved | go.mod upgraded; not present in binary (test-only dep) — Trivy confirms absent |

---

### Changes Made

| File | Change |
|------|--------|
| `go.mod` | `gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b` → `v3.0.1` |
| `go.sum` | Added hash entries for `gopkg.in/yaml.v3 v3.0.1` |

**Version selection rationale:**
- `gopkg.in/yaml.v3 v3.0.1` is the first stable release that fixes CVE-2022-28948. It is a patch bump from the pre-release snapshot previously pinned.

---

### ⚠️ Scanner Evidence Missing

OnDemand (Prisma Cloud) scans could not be triggered due to `NG_ACCESS_DENIED`. A maintainer with appropriate Harness permissions should run the OnDemand scan against:
- Baseline: `plugins/buildx:1.3.24` (connector: `docker.io`)
- After: `vinayakharness/buildx-test:buildx-1.3.25--debug` (connector: `docker.io`)

Trivy local scans were run successfully and confirm CVE-2022-28948 is absent from the production binary in the test image.

[CI-22906]: https://harness.atlassian.net/browse/CI-22906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ