### PR TITLE
fix: [CI-22906]: bump gopkg.in/yaml.v3 to v3.0.1 to remediate CVE-2022-28948

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.26

--- a/go.sum
+++ b/go.sum
@@ -71,5 +71,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Vulnerability Remediation: plugins/buildx

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-22906](https://harness.atlassian.net/browse/CI-22906)
**Test image:** `vinayakharness/buildx-test:buildx-1.3.25--debug`

**OnDemand scanner runs (Harness harness0.harness.io):**
- Baseline: N/A — service account `bot` lacks `core_pipeline_execute` on `Ondemand_Vulnerability_Scanner`
- After: N/A — same reason; OnDemand scan must be triggered manually or after permission grant

---

### Summary

CVE-2022-28948 is a High-severity YAML unmarshaller DoS in `gopkg.in/yaml.v3` prior to v3.0.1.
The pre-release hash `v3.0.0-20210107192922-496545a6307b` was pinned as an indirect dependency.
This PR bumps it to the patched release `v3.0.1` (minimum safe version). The test image
`vinayakharness/buildx-test:buildx-1.3.25--debug` was built from this branch and scanned locally
with Trivy — CVE-2022-28948 is not reported by Trivy in either the baseline or after image (the
CVE lives in the compiled Go binary; Trivy's OS-layer scan does not surface it, but the Prisma
Cloud / Harness OnDemand scanner does via source-map analysis). OnDemand scan is blocked by a
permission issue — `RECOMMENDATION=WAIT` until a human triggers the scan and confirms the result.

---

### CVE Delta — Trivy (local scan)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 15     | 15    | 0      |
| High     | 259    | 259   | 0      |
| Medium   | 242    | 242   | 0      |
| Low      | 69     | 69    | 0      |
| Total    | 585    | 585   | 0      |

> Note: CVE-2022-28948 is a Go module CVE embedded in the compiled binary. Trivy's image scan
> does not surface it in either the baseline or after image — it requires language-aware scanning
> (Prisma Cloud / Harness STO). The delta will appear in the OnDemand scan.

---

### Per-Ticket CVE Status

#### CI-22906 — [High: CVE-2022-28948 — gopkg.in/yaml.v3 DoS](https://harness.atlassian.net/browse/CI-22906)

**Summary:** `gopkg.in/yaml.v3` at the pre-release hash `v3.0.0-20210107192922-496545a6307b` is a
direct indirect dependency in `go.mod`. It was bumped to the patched release `v3.0.1`, which is
the minimum version containing the DoS fix. The change was validated by checking the `go.sum`
hash and confirming the module graph still resolves correctly.

| CVE | Package | Before | After | Required | Status | Reason |
|-----|---------|--------|-------|----------|--------|--------|
| CVE-2022-28948 | gopkg.in/yaml.v3 | v3.0.0-20210107192922-496545a6307b | v3.0.1 | v3.0.1+ | ✅ Resolved (code) | go.mod bumped to v3.0.1; awaiting OnDemand scan confirmation |

---

### Changes Made

| File | Change |
|------|--------|
| `go.mod` | `gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b` → `gopkg.in/yaml.v3 v3.0.1` |
| `go.sum` | Updated hashes for `gopkg.in/yaml.v3 v3.0.1` |

**Version selection rationale:**
- `gopkg.in/yaml.v3 v3.0.1` is the minimum patched release for CVE-2022-28948. v3.0.1 is the first GA release (the installed version was a pre-release commit hash). No major version boundary crossed.

---

### Newly Introduced CVEs

None. Trivy count is identical between baseline and test image.

---

> **SCANNER_STATUS: NOT_CONFIRMED** — OnDemand scan skipped (service account lacks
> `core_pipeline_execute` permission). A maintainer should manually trigger the
> `Ondemand_Vulnerability_Scanner` pipeline against `vinayakharness/buildx-test:buildx-1.3.25--debug`
> and update this PR with the results before merging.

[CI-22906]: https://harness.atlassian.net/browse/CI-22906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ