### PR TITLE
feat: [CI-23756]: windows 2025 rf stage

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -908,7 +908,7 @@ pipeline:
                           go build -buildvcs=false -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
                   - step:
                       type: Plugin
-                      name: "Build and Push on Tag "
+                      name: Build and Push on Tag
                       identifier: Plugin_1
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
@@ -923,6 +923,98 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: <+codebase.build.type> == "tag"
+                  - step:
+                      type: BuildAndPushDockerRegistry
+                      name: Build and Push on Branch
+                      identifier: BuildAndPushDockerRegistry_2
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        repo: plugins/buildx
+                        tags:
+                          - windows-ltsc2025-amd64
+                        caching: false
+                        dockerfile: docker/docker/Dockerfile.windows.amd64.ltsc2025
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "branch"
+        - stage:
+            name: win-ltsc2025-amd64-rf
+            identifier: winltsc2025amd64rf
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              caching:
+                enabled: false
+                paths: []
+              buildIntelligence:
+                enabled: false
+              infrastructure:
+                type: VM
+                spec:
+                  type: Pool
+                  spec:
+                    poolName: windows-2025
+                    os: Windows
+              execution:
+                steps:
+                  - step:
+                      type: GitClone
+                      name: Clone RF Dockerfiles
+                      identifier: Clone_RF_Dockerfiles
+                      spec:
+                        connectorRef: RapidFortPlugins
+                        cloneDirectory: rf-plugins
+                        build:
+                          type: branch
+                          spec:
+                            branch: main
+                  - step:
+                      type: Run
+                      name: Build Binary -ltsc2025
+                      identifier: build_amd64ltsc2025
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        image: golang:1.23.0
+                        shell: Sh
+                        command: |-
+                          # disable cgo
+                          export CGO_ENABLED=0
+
+                          go build -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
+                        envVariables:
+                          CGO_ENABLED: "0"
+                  - step:
+                      type: Plugin
+                      name: RF Build and Push on Tag
+                      identifier: RF_Build_and_Push_on_Tag
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        image: plugins/docker:windows-ltsc2025-amd64
+                        settings:
+                          username: <+secrets.getValue("harnesssecureusername")>
+                          password: <+secrets.getValue("dockerHarnessSecurePwd")>
+                          repo: harnesssecure/buildx
+                          dockerfile: rf-plugins/drone-buildx/Dockerfile.windows.amd64.ltsc2025
+                          auto_tag: "true"
+                          auto_tag_suffix: windows-ltsc2025-amd64
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "tag"
+                  - step:
+                      type: BuildAndPushDockerRegistry
+                      name: RF Build and Push on Branch
+                      identifier: rf_build_push_branch
+                      spec:
+                        connectorRef: harnesssecure
+                        repo: harnesssecure/buildx
+                        tags:
+                          - windows-ltsc2025-amd64
+                        caching: false
+                        dockerfile: rf-plugins/drone-buildx/Dockerfile.windows.amd64.ltsc2025
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "branch"
     - parallel:
         - stage:
             identifier: Manifest

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -975,15 +975,22 @@ pipeline:
                       identifier: build_amd64ltsc2025
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.23.0
+                        image: golang:1.26
                         shell: Sh
                         command: |-
+                          # force go modules
+                          export GOPATH=""
+
                           # disable cgo
                           export CGO_ENABLED=0
 
-                          go build -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
-                        envVariables:
-                          CGO_ENABLED: "0"
+                          set -e
+                          set -x
+
+                          # windows
+                          GOOS=windows
+
+                          go build -buildvcs=false -o release/windows/amd64/drone-docker.exe ./cmd/drone-docker
                   - step:
                       type: Plugin
                       name: RF Build and Push on Tag


### PR DESCRIPTION
## feat: [CI-23756]: windows 2025 rf stage

### Changes
- **Fix `win-ltsc-2025-amd64` stage**: `os` was incorrectly set to `Linux` — corrected to `Windows`
- **Add missing branch push step** to `win-ltsc-2025-amd64` stage (`Build and Push on Branch`)
- **Add new `win-ltsc2025-amd64-rf` stage**: RapidFort-hardened Windows Server 2025 build using `plugins/docker:windows-ltsc2025-amd64` and `rf-plugins/drone-buildx/Dockerfile.windows.amd64.ltsc2025`

[CI-23756]: https://harness.atlassian.net/browse/CI-23756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ